### PR TITLE
Topgrade options that cause errors in the company Mac are disabled.

### DIFF
--- a/.config/topgrade.toml
+++ b/.config/topgrade.toml
@@ -15,7 +15,12 @@
 # sudo_command = "sudo"
 
 # Disable specific steps - same options as the command line flag
-disable = ["vim"]
+disable = [
+	"vim", # plug install does not work
+	"node", # node update hangs
+	"gem", # fails on macOS due to priviledge issues on the work computer.
+	"ruby_gems" # fails on macOS due to priviledge issues on the work computer.
+]
 
 # Ignore failures for these steps
 # ignore_failures = ["powershell"]

--- a/.gitconfig
+++ b/.gitconfig
@@ -50,5 +50,6 @@
 	ignore = update-index --assume-unchanged
 	unignore = update-index --no-assume-unchanged
 	ignored = !git ls-files -v | grep "^[[:lower:]]"
+	root = !git rev-parse --show-toplevel
 [pull]
 	rebase = true


### PR DESCRIPTION
Topgrade options that cause errors in the company Mac are disabled.
Also, an alias for getting the root of the current git project.